### PR TITLE
Adding elasticsearch char filter for transforming smart quotes into dumb ones

### DIFF
--- a/elastimorphic/base.py
+++ b/elastimorphic/base.py
@@ -228,6 +228,9 @@ class PolymorphicIndexable(object):
                 },
                 "properties": cls.get_mapping_properties(),
                 "dynamic": "strict",
+                "_all": {
+                    "analyzer": "html"
+                }
             }
         }
 

--- a/elastimorphic/conf/defaults.py
+++ b/elastimorphic/conf/defaults.py
@@ -6,15 +6,28 @@ ES_SETTINGS = {
             "analyzer": {
                 "autocomplete": {
                     "type": "custom",
+                    "char_filter": ["quotes"],
                     "tokenizer": "edge_ngram_tokenizer",
                     "filter": ["asciifolding", "lowercase"]
                 },
                 "html": {
                     "type": "custom",
-                    "char_filter": ["html_strip"],
+                    "char_filter": ["html_strip", "quotes"],
                     "tokenizer": "standard",
                     "filter": ["asciifolding", "lowercase", "stop", "snowball"]
                 }
+            },
+            "char_filter": {
+                "quotes": {
+                    "mappings": [
+                        "\u0091=>\u0027",
+                        "\u0092=>\u0027",
+                        "\u2018=>\u0027",
+                        "\u2019=>\u0027",
+                        "\uFF07=>\u0027"
+                    ],
+                    "type": "mapping"
+                },
             },
             "tokenizer": {
                 "edge_ngram_tokenizer": {


### PR DESCRIPTION
Fixes some annoying search bugs. Solution from http://elasticsearch-users.115913.n3.nabble.com/Filtering-for-apostrophes-and-single-quotes-confusion-td4035406.html
