### PR TITLE
update documentation for expected use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Usage
 * Include "elastimorphic" in your INSTALLED_APPS
 * Create models which subclass PolymorphicIndexable and PolymorphicModel
 * Implement the PolymorphicIndexable interfaces on your models
-* `manage.py synces` creates indexes for your models in elasticsearch
+* `manage.py synces <alias_name>` creates indexes for your models in elasticsearch with alias <dbname>_<app_name>_<model_name>_<alias_name>
+* `manage.py es_swap_aliases <alias_name>` activates the indexes in ES
+* `manage.py bulk_index` populates the index with data in the PolymorphicIndexable models
 
 Running tests
 -------------


### PR DESCRIPTION
Running synces with no aliases created causes the index creation to fail.  Expected use case is to use an alias for the table, so that should be reflected in the README.

If objects are inserted into the index without running synces management command, the mapping is not applied to the index and the analyzers and indexes don't work properly.
