### PR TITLE
Django 1.7: don't register abstract models

### DIFF
--- a/elastimorphic/apps.py
+++ b/elastimorphic/apps.py
@@ -10,6 +10,9 @@ class ElastimorphicConfig(AppConfig):
     def ready(self):
         def register_subclasses(klass):
             for subclass in klass.__subclasses__():
-                polymorphic_indexable_registry.register(subclass)
+                # only register concrete models
+                meta = getattr(subclass, "_meta")
+                if meta and not getattr(meta, "abstract"):
+                    polymorphic_indexable_registry.register(subclass)
                 register_subclasses(subclass)
         register_subclasses(PolymorphicIndexable)

--- a/elastimorphic/tests/testapp/models.py
+++ b/elastimorphic/tests/testapp/models.py
@@ -94,3 +94,15 @@ class GrandchildIndexable(ChildIndexable):
     def get_serializer_class(cls):
         from .serializers import GrandchildIndexableSerializer
         return GrandchildIndexableSerializer
+
+
+class PolyMixin(PolymorphicIndexable, models.Model):
+    itsa = models.TextField(default="", blank=True)
+    mixin = models.TextField(default="", blank=True)
+
+    class Meta:
+        abstract = True
+
+
+class MixedIndexable(SeparateIndexable, PolyMixin):
+    pass

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -18,7 +18,8 @@ from elastimorphic.tests.testapp.models import (
     ChildIndexable,
     GrandchildIndexable,
     ParentIndexable,
-    SeparateIndexable)
+    SeparateIndexable,
+    MixedIndexable)
 
 
 class IndexableTestCase(BaseIndexableTestCase):
@@ -50,6 +51,7 @@ class IndexableTestCase(BaseIndexableTestCase):
         self.assertEqual(
             SeparateIndexable.get_mapping_type_names(), [
                 SeparateIndexable.get_mapping_type_name(),
+                MixedIndexable.get_mapping_type_name(),
             ]
         )
 
@@ -247,7 +249,17 @@ class TestPolymorphicIndexableRegistry(TestCase):
         self.assertTrue(polymorphic_indexable_registry.all_models)
         self.assertTrue(polymorphic_indexable_registry.families)
         types = polymorphic_indexable_registry.get_doctypes(ParentIndexable)
-        desired_classes = set([ParentIndexable, ChildIndexable, GrandchildIndexable])
+        desired_classes = set([
+            ParentIndexable, ChildIndexable, GrandchildIndexable
+        ])
+        result_classes = set()
+        for name, klass in types.items():
+            result_classes.add(klass)
+        self.assertEqual(desired_classes, result_classes)
+
+    def test_registry_has_no_abstract_models(self):
+        types = polymorphic_indexable_registry.get_doctypes(SeparateIndexable)
+        desired_classes = set([SeparateIndexable, MixedIndexable])
         result_classes = set()
         for name, klass in types.items():
             result_classes.add(klass)


### PR DESCRIPTION
Looks like this was the behavior for Django < 1.7 using the `class_prepared` signal.
